### PR TITLE
Update the default mounting position for the arm

### DIFF
--- a/dingo_kinova_description/urdf/dingo_gen3_lite_description.urdf.xacro
+++ b/dingo_kinova_description/urdf/dingo_gen3_lite_description.urdf.xacro
@@ -14,7 +14,32 @@
 
   <joint name="arm_mount_joint" type="fixed">
     <origin xyz="$(optenv DINGO_ARM_XYZ 0.0 0.0 0.0)" rpy="$(optenv DINGO_ARM_RPY 0 0 0)"/>
-    <parent link="mid_mount" />
+    <parent link="$(optenv DINGO_ARM_MOUNT front_b_mount)" />
     <child link="$(arg prefix)base_link" />
   </joint>
+
+  <xacro:if value="$(optenv DINGO_ARM_EXTERNAL_POWER 0)">
+    <link name="$(arg arm)_power">
+      <visual>
+        <geometry>
+          <box size="0.185 0.1 0.04" />
+        </geometry>
+        <material name="white">
+          <color rgba="1 1 1 1" />
+        </material>
+        <origin xyz="0 0 0.02" rpy="0 0 0" />
+      </visual>
+      <collision>
+        <geometry>
+          <box size="0.185 0.1 0.04" />
+        </geometry>
+        <origin xyz="0 0 0.02" rpy="0 0 0" />
+      </collision>
+    </link>
+    <joint name="$(arg arm)_power_joint" type="fixed">
+      <parent link="$(optenv DINGO_ARM_EXTERNAL_POWER_MOUNT rear_b_mount)"/>
+      <child link="$(arg arm)_power" />
+      <origin xyz="$(optenv DINGO_ARM_EXTERNAL_POWER_XYZ 0 0 0)" rpy="$(optenv DINGO_ARM_EXTERNAL_POWER_RPY 0 0 0)" />
+    </joint>
+  </xacro:if>
 </robot>


### PR DESCRIPTION
Update the default mounting position for the arm to be the front-b mount, add an option to include the external power regulator needed on dingo-d.

The arm now attaches to front_b_mount by default.  External power, if present, mounts to rear_b_mount by default.  New env vars allow easy customization of the mount point for both.

Waiting on approval of https://github.com/dingo-cpr/dingo/pull/9 before merging this.