### PR TITLE
Prefix and MoveIt! changes

### DIFF
--- a/dingo_gen3_lite_moveit_config/config/dingo_d_controllers.yaml
+++ b/dingo_gen3_lite_moveit_config/config/dingo_d_controllers.yaml
@@ -25,7 +25,7 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: 50
 controller_list:
-  - name: arm/gen3_lite_joint_trajectory_controller
+  - name: arm/arm_gen3_lite_joint_trajectory_controller
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
     joints:

--- a/dingo_gen3_lite_moveit_config/config/dingo_o_controllers.yaml
+++ b/dingo_gen3_lite_moveit_config/config/dingo_o_controllers.yaml
@@ -17,6 +17,7 @@ hardware_interface:
     - arm_joint_4
     - arm_joint_5
     - arm_joint_6
+    - arm_right_finger_bottom_joint
     - rear_left_wheel
     - rear_right_wheel
   sim_control_mode: 1  # 0: position, 1: velocity

--- a/dingo_gen3_lite_moveit_config/config/dingo_o_controllers.yaml
+++ b/dingo_gen3_lite_moveit_config/config/dingo_o_controllers.yaml
@@ -17,7 +17,6 @@ hardware_interface:
     - arm_joint_4
     - arm_joint_5
     - arm_joint_6
-    - arm_right_finger_bottom_joint
     - rear_left_wheel
     - rear_right_wheel
   sim_control_mode: 1  # 0: position, 1: velocity

--- a/dingo_gen3_lite_moveit_config/config/dingo_o_controllers.yaml
+++ b/dingo_gen3_lite_moveit_config/config/dingo_o_controllers.yaml
@@ -26,7 +26,7 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: 50
 controller_list:
-  - name: arm/gen3_lite_joint_trajectory_controller
+  - name: arm/arm_gen3_lite_joint_trajectory_controller
     action_ns: follow_joint_trajectory
     default: True
     type: FollowJointTrajectory

--- a/dingo_gen3_lite_moveit_config/config/ompl_planning.yaml
+++ b/dingo_gen3_lite_moveit_config/config/ompl_planning.yaml
@@ -121,7 +121,7 @@ planner_configs:
     dense_delta_fraction: 0.001  # delta fraction for interface detection. default: 0.001
     max_failures: 5000  # maximum consecutive failure limit. default: 5000
 manipulator:
-  default_planner_config: None
+  default_planner_config: RRTConnect
   planner_configs:
     - SBL
     - EST

--- a/dingo_gen3_lite_moveit_config/config/ros_controllers.yaml
+++ b/dingo_gen3_lite_moveit_config/config/ros_controllers.yaml
@@ -25,7 +25,7 @@ joint_state_controller:
   type: joint_state_controller/JointStateController
   publish_rate: 50
 controller_list:
-  - name: arm/gen3_lite_joint_trajectory_controller
+  - name: arm/arm_gen3_lite_joint_trajectory_controller
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
     joints:

--- a/dingo_gen3_lite_moveit_config/launch/ompl_planning_pipeline.launch.xml
+++ b/dingo_gen3_lite_moveit_config/launch/ompl_planning_pipeline.launch.xml
@@ -18,7 +18,7 @@
   <param name="request_adapters" value="$(arg planning_adapters)" />
   <param name="start_state_max_bounds_error" value="$(arg start_state_max_bounds_error)" />
 
-  <param name="sample_duration" value="0.001"/>
+  <param name="sample_duration" value="0.1"/>
 
   <rosparam command="load" file="$(find dingo_gen3_lite_moveit_config)/config/ompl_planning.yaml"/>
 

--- a/dingo_gen3_lite_moveit_config/launch/trajectory_execution.launch.xml
+++ b/dingo_gen3_lite_moveit_config/launch/trajectory_execution.launch.xml
@@ -7,7 +7,7 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="2.0"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->

--- a/dingo_kinova_description/urdf/dingo_gen3_lite_description.urdf.xacro
+++ b/dingo_kinova_description/urdf/dingo_gen3_lite_description.urdf.xacro
@@ -7,7 +7,7 @@
   <xacro:arg name="gripper" default="$(optenv DINGO_ARM_GRIPPER gen3_lite_2f)" />
 
   <xacro:arg name="sim" default="$(optenv DINGO_ARM_SIM false)" />
-  <xacro:arg name="prefix" default="$(optenv DINGO_ARM_PREFIX arm_)" />
+  <xacro:arg name="prefix" default="$(optenv DINGO_ARM_PREFIX arm)_" />
 
   <xacro:include filename="$(find kortex_description)/robots/kortex_robot.xacro" />
   <xacro:load_robot arm="$(arg arm)" gripper="$(arg gripper)" dof="$(arg dof)" vision="$(arg vision)" sim="$(arg sim)" prefix="$(arg prefix)" />


### PR DESCRIPTION
Previous prefix had an underscore: `arm_`, this was causing trouble with the bringup launch file since it assumed that the prefix would be used as the name of the node. In turn, changed node names for the action server meant that MoveIt would not work. 

Additionally, MoveIt! had an old naming scheme for the action server follow trajectory topic. Instead of: `/arm/gen3_...` it is now `/arm/arm_gen3_...`. 

I also decreased the speed of execution and increased allowed time in order to accommodate Kinova's slow movement. 