### PR TITLE
Added Gen3 Lite Gripper

### DIFF
--- a/dingo_gen3_lite_moveit_config/config/dingo.srdf
+++ b/dingo_gen3_lite_moveit_config/config/dingo.srdf
@@ -12,6 +12,9 @@
     <group name="manipulator">
         <chain base_link="arm_base_link" tip_link="arm_end_effector_link" />
     </group>
+    <group name="gripper">
+        <chain base_link="arm_gripper_base_link" tip_link="arm_right_finger_prox_link"/>
+    </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="vertical" group="manipulator">
         <joint name="arm_joint_1" value="0" />
@@ -28,6 +31,12 @@
         <joint name="arm_joint_4" value="1.55" />
         <joint name="arm_joint_5" value="1.33" />
         <joint name="arm_joint_6" value="-1.55" />
+    </group_state>
+    <group_state name="closed" group="gripper">
+        <joint name="arm_right_finger_bottom_joint" value="-0.09"/>
+    </group_state>
+    <group_state name="open" group="gripper">
+        <joint name="arm_right_finger_bottom_joint" value="0.96"/>
     </group_state>
     <!--PASSIVE JOINT: Purpose: this element is used to mark joints that are not actuated-->
     <passive_joint name="left_wheel" />

--- a/dingo_gen3_lite_moveit_config/config/dingo_d.srdf
+++ b/dingo_gen3_lite_moveit_config/config/dingo_d.srdf
@@ -12,6 +12,9 @@
     <group name="manipulator">
         <chain base_link="arm_base_link" tip_link="arm_end_effector_link" />
     </group>
+    <group name="gripper">
+        <chain base_link="arm_gripper_base_link" tip_link="arm_right_finger_prox_link"/>
+    </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="vertical" group="manipulator">
         <joint name="arm_joint_1" value="0" />
@@ -28,6 +31,12 @@
         <joint name="arm_joint_4" value="1.55" />
         <joint name="arm_joint_5" value="1.33" />
         <joint name="arm_joint_6" value="-1.55" />
+    </group_state>
+    <group_state name="closed" group="gripper">
+        <joint name="arm_right_finger_bottom_joint" value="-0.09"/>
+    </group_state>
+    <group_state name="open" group="gripper">
+        <joint name="arm_right_finger_bottom_joint" value="0.96"/>
     </group_state>
     <!--PASSIVE JOINT: Purpose: this element is used to mark joints that are not actuated-->
     <passive_joint name="left_wheel" />

--- a/dingo_gen3_lite_moveit_config/config/dingo_d_controllers.yaml
+++ b/dingo_gen3_lite_moveit_config/config/dingo_d_controllers.yaml
@@ -35,3 +35,8 @@ controller_list:
       - arm_joint_4
       - arm_joint_5
       - arm_joint_6
+  - name: arm/arm_gen3_lite_2f_gripper_controller
+    action_ns: gripper_cmd
+    type: GripperCommand
+    joints:
+      - arm_right_finger_bottom_joint

--- a/dingo_gen3_lite_moveit_config/config/dingo_o.srdf
+++ b/dingo_gen3_lite_moveit_config/config/dingo_o.srdf
@@ -12,6 +12,9 @@
     <group name="manipulator">
         <chain base_link="arm_base_link" tip_link="arm_end_effector_link" />
     </group>
+    <group name="gripper">
+        <chain base_link="arm_gripper_base_link" tip_link="arm_right_finger_prox_link"/>
+    </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="vertical" group="manipulator">
         <joint name="arm_joint_1" value="0" />
@@ -28,6 +31,12 @@
         <joint name="arm_joint_4" value="1.55" />
         <joint name="arm_joint_5" value="1.33" />
         <joint name="arm_joint_6" value="-1.55" />
+    </group_state>
+    <group_state name="closed" group="gripper">
+        <joint name="arm_right_finger_bottom_joint" value="-0.09"/>
+    </group_state>
+    <group_state name="open" group="gripper">
+        <joint name="arm_right_finger_bottom_joint" value="0.96"/>
     </group_state>
     <!--PASSIVE JOINT: Purpose: this element is used to mark joints that are not actuated-->
     <passive_joint name="arm_right_finger_tip_joint" />

--- a/dingo_gen3_lite_moveit_config/config/dingo_o_controllers.yaml
+++ b/dingo_gen3_lite_moveit_config/config/dingo_o_controllers.yaml
@@ -37,3 +37,8 @@ controller_list:
       - arm_joint_4
       - arm_joint_5
       - arm_joint_6
+  - name: arm/arm_gen3_lite_2f_gripper_controller
+    action_ns: gripper_cmd
+    type: GripperCommand
+    joints:
+      - arm_right_finger_bottom_joint

--- a/dingo_gen3_lite_moveit_config/config/ros_controllers.yaml
+++ b/dingo_gen3_lite_moveit_config/config/ros_controllers.yaml
@@ -35,3 +35,8 @@ controller_list:
       - arm_joint_4
       - arm_joint_5
       - arm_joint_6
+  - name: arm/arm_gen3_lite_2f_gripper_controller
+    action_ns: gripper_cmd
+    type: GripperCommand
+    joints:
+      - arm_right_finger_bottom_joint

--- a/dingo_gen3_lite_moveit_config/launch/trajectory_execution.launch.xml
+++ b/dingo_gen3_lite_moveit_config/launch/trajectory_execution.launch.xml
@@ -9,7 +9,7 @@
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
   <param name="trajectory_execution/allowed_execution_duration_scaling" value="2.0"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="2.0"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
   <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
 


### PR DESCRIPTION
Gen3 Lite arms **always** have a gripper and it must be the standard Kinova gripper. Therefore, create a MoveIt! config for it makes sense.