### PR TITLE
Disable load_robot_description

### DIFF
--- a/dingo_gen3_lite_moveit_config/launch/move_group.launch
+++ b/dingo_gen3_lite_moveit_config/launch/move_group.launch
@@ -37,7 +37,7 @@
                 " />
   -->
 
-  <arg name="load_robot_description" default="true" />
+  <arg name="load_robot_description" default="false" />
   <!-- load URDF, SRDF and joint_limits configuration -->
   <include file="$(find dingo_gen3_lite_moveit_config)/launch/planning_context.launch">
     <arg name="load_robot_description" value="$(arg load_robot_description)" />


### PR DESCRIPTION
By default it was re-defining the robot_description rosparam. It must be set to false